### PR TITLE
Use decoded lat/lng for OSM links instead of address search

### DIFF
--- a/pcd-website/src/lib/popup.ts
+++ b/pcd-website/src/lib/popup.ts
@@ -19,10 +19,8 @@ function t(key: string, params?: Record<string, string>): string {
 const POPUP_PREVIEW_LENGTH = 120;
 
 export function getOsmUrl(node: Node): string {
-  const query = node.location_name
-    ? [node.location_name, node.address].filter(Boolean).join(', ')
-    : node.address ?? '';
-  return `https://www.openstreetmap.org/search?query=${encodeURIComponent(query)}`;
+  const { lat, lng } = node;
+  return `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lng}#map=18/${lat}/${lng}`;
 }
 
 export function makePopupContent(node: Node): string {


### PR DESCRIPTION
The OSM venue links did a fuzzy text search on the address, which is unreliable. Plus codes are already decoded to lat/lng at build time, so point the links straight at those coordinates instead.