### PR TITLE
Fix styling and markdown support

### DIFF
--- a/pcd-website/src/components/NodePanel.vue
+++ b/pcd-website/src/components/NodePanel.vue
@@ -818,7 +818,7 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
 }
 
 .panel-inline-md :deep(a:hover) {
-  color: inherit;
+  color: var(--color-link-hover);
 }
 
 .panel-inline-md :deep(code) {

--- a/pcd-website/src/components/NodePanel.vue
+++ b/pcd-website/src/components/NodePanel.vue
@@ -876,13 +876,13 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
   cursor: pointer;
   font-family: var(--font-family);
   font-size: inherit;
-  color: var(--color-link);
+  color: var(--color-text-muted);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .panel-hosts-more:hover {
-  color: var(--color-link-hover);
+  color: var(--color-text);
 }
 
 /* ─── Event website CTA ─── */
@@ -1235,13 +1235,13 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
   cursor: pointer;
   font-family: var(--font-family);
   font-size: 0.875rem;
-  color: var(--color-link);
+  color: var(--color-text-muted);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .panel-read-more:hover {
-  color: var(--color-link-hover);
+  color: var(--color-text);
 }
 
 /* ─── Links section ─── */

--- a/pcd-website/src/components/NodePanel.vue
+++ b/pcd-website/src/components/NodePanel.vue
@@ -31,7 +31,7 @@ let minimap: import('leaflet').Map | null = null;
 
 // Collapsed height of the description, in px. Must match the max-height set on
 // .panel-description-content--clamped in the styles below.
-const DESC_CLAMP_PX = 132;
+const DESC_CLAMP_PX = 240;
 const HOSTS_VISIBLE = 3;
 
 function handleOutsideClick(e: MouseEvent) {
@@ -1121,7 +1121,7 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
 /* Collapse long descriptions behind a "read more" toggle. The max-height here
    must match DESC_CLAMP_PX in the script. */
 .panel-description-content--clamped {
-  max-height: 132px;
+  max-height: 240px;
   overflow: hidden;
   -webkit-mask-image: linear-gradient(to bottom, #000 60%, transparent 100%);
   mask-image: linear-gradient(to bottom, #000 60%, transparent 100%);

--- a/pcd-website/src/components/NodePanel.vue
+++ b/pcd-website/src/components/NodePanel.vue
@@ -376,7 +376,7 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
           <!-- Row 2: Venue + address (OSM link) or Online platform -->
           <div class="info-card-row info-card-venue-row">
             <div class="info-card-row-leading">
-              <Icon icon="bi:link-45deg" width="1em" height="1em" aria-hidden="true" class="info-card-icon" />
+              <Icon :icon="!node.online_event && node.location_tbd ? 'bi:geo-alt' : 'bi:link-45deg'" width="1em" height="1em" aria-hidden="true" class="info-card-icon" />
               <div class="info-card-venue">
                 <span class="info-card-venue-name">{{ node.online_event ? onlinePlatformName(node.event_url) : node.location_tbd ? t('panel.location_tbd') : (node.location_name || node.address) }}</span>
                 <a

--- a/pcd-website/src/components/NodePanel.vue
+++ b/pcd-website/src/components/NodePanel.vue
@@ -812,13 +812,13 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
 }
 
 .panel-inline-md :deep(a) {
-  color: var(--color-link);
+  color: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .panel-inline-md :deep(a:hover) {
-  color: var(--color-link-hover);
+  color: inherit;
 }
 
 .panel-inline-md :deep(code) {
@@ -1141,13 +1141,13 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
 }
 
 .panel-description-content :deep(a) {
-  color: var(--color-link);
+  color: var(--color-text);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .panel-description-content :deep(a:hover) {
-  color: var(--color-link-hover);
+  color: var(--color-text);
 }
 
 .panel-description-content :deep(h1),

--- a/pcd-website/src/components/NodePanel.vue
+++ b/pcd-website/src/components/NodePanel.vue
@@ -161,18 +161,22 @@ function downloadIcs(node: Node) {
 }
 
 
-function getOrganizerNames(organizers: { name: string }[]): string[] {
-  return organizers.map(o => o.name).filter(Boolean);
+type Organizer = { name: string; name_html: string };
+
+function getOrganizers(organizers: Organizer[]): Organizer[] {
+  return organizers.filter(o => o.name);
 }
 
-function formatOrganizers(organizers: { name: string }[], expanded = false): string {
-  const names = getOrganizerNames(organizers);
-  if (expanded || names.length <= HOSTS_VISIBLE) return names.join(', ');
-  return names.slice(0, HOSTS_VISIBLE).join(', ');
+// Join organizer names as inline HTML (names support markdown, so name_html
+// carries the rendered markup). The separator is plain text between spans.
+function formatOrganizers(organizers: Organizer[], expanded = false): string {
+  const list = getOrganizers(organizers);
+  const visible = expanded ? list : list.slice(0, HOSTS_VISIBLE);
+  return visible.map(o => o.name_html).join(', ');
 }
 
-function hasMoreHosts(organizers: { name: string }[]): boolean {
-  return getOrganizerNames(organizers).length > HOSTS_VISIBLE;
+function hasMoreHosts(organizers: Organizer[]): boolean {
+  return getOrganizers(organizers).length > HOSTS_VISIBLE;
 }
 
 function getShareUrl(node: Node): string {
@@ -323,14 +327,14 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
         </div>
         <div class="panel-byline">
           <p v-if="node.organization_name" class="panel-organizing-entity">
-            <span class="panel-label">{{ t('panel.by') }}</span> {{ node.organization_name }}
+            <span class="panel-label">{{ t('panel.by') }}</span> <span class="panel-inline-md" v-html="node.organization_name_html"></span>
           </p>
           <p v-if="node.organizers.some(o => o.name)" class="panel-hosts">
             <span class="panel-label">{{ t('panel.hosts_label') }}</span>
             <span v-if="!hostsExpanded" class="panel-hosts-line">
-              <span class="panel-hosts-names">{{ formatOrganizers(node.organizers, false) }}</span><template v-if="hasMoreHosts(node.organizers)"><span class="panel-hosts-more-wrap">…&nbsp;<button class="panel-hosts-more" :aria-label="t('panel.show_all_hosts')" @click="hostsExpanded = true">{{ t('panel.more') }}</button></span></template>
+              <span class="panel-hosts-names panel-inline-md" v-html="formatOrganizers(node.organizers, false)"></span><template v-if="hasMoreHosts(node.organizers)"><span class="panel-hosts-more-wrap">…&nbsp;<button class="panel-hosts-more" :aria-label="t('panel.show_all_hosts')" @click="hostsExpanded = true">{{ t('panel.more') }}</button></span></template>
             </span>
-            <span v-else>{{ formatOrganizers(node.organizers, true) }}</span>
+            <span v-else class="panel-inline-md" v-html="formatOrganizers(node.organizers, true)"></span>
           </p>
         </div>
 
@@ -792,6 +796,30 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
 
 [data-theme="dark"] .panel-activity-tag {
   border-color: var(--color-border-light);
+}
+
+/* Inline markdown rendered via v-html (host/org names, disclaimer). */
+.panel-inline-md :deep(em) {
+  font-style: italic;
+}
+
+.panel-inline-md :deep(strong) {
+  font-weight: 600;
+}
+
+.panel-inline-md :deep(a) {
+  color: var(--color-link);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.panel-inline-md :deep(a:hover) {
+  color: var(--color-link-hover);
+}
+
+.panel-inline-md :deep(code) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
 }
 
 .panel-organizing-entity {

--- a/pcd-website/src/components/NodePanel.vue
+++ b/pcd-website/src/components/NodePanel.vue
@@ -532,9 +532,13 @@ const calLinks = computed(() => props.node && !props.node.date_tbd ? calendarLin
         <!-- Disclaimer -->
         <template v-if="!node.organization_name?.toLowerCase().includes('processing foundation')">
           <hr class="panel-separator" aria-hidden="true" />
-          <p v-if="node.organization_name" class="panel-disclaimer">
-            {{ t('panel.disclaimer_with_org', { org: node.organization_name }) }}
-          </p>
+          <!-- disclaimer_with_org wraps {org} in <em>; org name may itself
+               contain PR-reviewed inline markdown, so inject as HTML. -->
+          <p
+            v-if="node.organization_name"
+            class="panel-disclaimer panel-inline-md"
+            v-html="t('panel.disclaimer_with_org', { org: node.organization_name_html })"
+          ></p>
           <p v-else class="panel-disclaimer">
             {{ t('panel.disclaimer_without_org') }}
           </p>

--- a/pcd-website/src/i18n/locales/de.json
+++ b/pcd-website/src/i18n/locales/de.json
@@ -84,7 +84,7 @@
         "download_ics": ".ics herunterladen",
         "read_more": "Mehr anzeigen",
         "show_less": "Weniger anzeigen",
-        "disclaimer_with_org": "Diese Veranstaltung wird von {org} organisiert und ist nicht mit der Processing Foundation verbunden. Bei Fragen zu dieser Veranstaltung wenden Sie sich bitte direkt an die Organisator:innen.",
+        "disclaimer_with_org": "Diese Veranstaltung wird von <em>{org}</em> organisiert und ist nicht mit der Processing Foundation verbunden. Bei Fragen zu dieser Veranstaltung wenden Sie sich bitte direkt an die Organisator:innen.",
         "disclaimer_without_org": "Diese Veranstaltung wird unabhängig organisiert und ist nicht mit der Processing Foundation verbunden. Bei Fragen zu dieser Veranstaltung wenden Sie sich bitte direkt an die Organisator:innen.",
         "activities_label": "Aktivitäten",
         "report_issue": "Ein Problem auf dieser Seite melden",

--- a/pcd-website/src/i18n/locales/en.json
+++ b/pcd-website/src/i18n/locales/en.json
@@ -84,7 +84,7 @@
         "download_ics": "Download .ics",
         "read_more": "Read more…",
         "show_less": "Show less",
-        "disclaimer_with_org": "This event is organized by {org} and is not affiliated with the Processing Foundation. For any questions or concerns about this event, please contact the organizers directly.",
+        "disclaimer_with_org": "This event is organized by <em>{org}</em> and is not affiliated with the Processing Foundation. For any questions or concerns about this event, please contact the organizers directly.",
         "disclaimer_without_org": "This event is independently organized and is not affiliated with the Processing Foundation. For any questions or concerns about this event, please contact the organizers directly.",
         "activities_label": "Activities",
         "report_issue": "Report an issue on this page",

--- a/pcd-website/src/i18n/locales/es.json
+++ b/pcd-website/src/i18n/locales/es.json
@@ -84,7 +84,7 @@
         "download_ics": "Descargar archivo .ics",
         "read_more": "Leer más…",
         "show_less": "Mostrar menos",
-        "disclaimer_with_org": "Este evento está organizado de forma independiente y no está afiliado con la Processing Foundation.Para cualquier pregunta o inquietud sobre este evento, comuníquese directamente con {org}.",
+        "disclaimer_with_org": "Este evento está organizado de forma independiente y no está afiliado con la Processing Foundation.Para cualquier pregunta o inquietud sobre este evento, comuníquese directamente con <em>{org}</em>.",
         "disclaimer_without_org": "Este evento está organizado de forma independiente y no está afiliado con la Processing Foundation. Para cualquier pregunta o inquietud sobre este evento, comuníquese directamente con los/as organizadores/as.",
         "activities_label": "Actividades",
         "report_issue": "Reportar un problema en esta página",

--- a/pcd-website/src/i18n/locales/fr.json
+++ b/pcd-website/src/i18n/locales/fr.json
@@ -84,7 +84,7 @@
         "download_ics": "Télécharger le fichier .ics",
         "read_more": "Afficher plus…",
         "show_less": "Afficher moins",
-        "disclaimer_with_org": "Cet événement est organisé de manière indépendante et n'est pas affilié à la Processing Foundation. Pour toute question concernant cet événement, veuillez contacter directement {org}.",
+        "disclaimer_with_org": "Cet événement est organisé de manière indépendante et n'est pas affilié à la Processing Foundation. Pour toute question concernant cet événement, veuillez contacter directement <em>{org}</em>.",
         "disclaimer_without_org": "Cet événement est organisé de manière indépendante et n'est pas affilié à la Processing Foundation. Pour toute question concernant cet événement, veuillez contacter directement les organisateur·rice·s.",
         "activities_label": "Activités",
         "report_issue": "Signaler un problème sur cette page",

--- a/pcd-website/src/i18n/locales/ja.json
+++ b/pcd-website/src/i18n/locales/ja.json
@@ -84,7 +84,7 @@
         "download_ics": ".ics をダウンロード",
         "read_more": "もっと読む…",
         "show_less": "折りたたむ",
-        "disclaimer_with_org": "このイベントは {org} が主催しており、Processing Foundation とは直接の関係はありません。このイベントに関するご質問・ご不明点は、主催者に直接お問い合わせください。",
+        "disclaimer_with_org": "このイベントは <em>{org}</em> が主催しており、Processing Foundation とは直接の関係はありません。このイベントに関するご質問・ご不明点は、主催者に直接お問い合わせください。",
         "disclaimer_without_org": "このイベントは独自に主催されており、Processing Foundation とは直接の関係はありません。このイベントに関するご質問・ご不明点は、主催者に直接お問い合わせください。",
         "activities_label": "アクティビティ",
         "report_issue": "このページの問題を報告",

--- a/pcd-website/src/i18n/locales/ko.json
+++ b/pcd-website/src/i18n/locales/ko.json
@@ -84,7 +84,7 @@
         "download_ics": ".ics 다운로드",
         "read_more": "더 읽기…",
         "show_less": "접기",
-        "disclaimer_with_org": "이 이벤트는 {org}이(가) 주최하며 Processing Foundation과 관련이 없습니다. 이 이벤트에 관한 질문이나 우려 사항은 주최자에게 직접 문의하세요.",
+        "disclaimer_with_org": "이 이벤트는 <em>{org}</em>이(가) 주최하며 Processing Foundation과 관련이 없습니다. 이 이벤트에 관한 질문이나 우려 사항은 주최자에게 직접 문의하세요.",
         "disclaimer_without_org": "이 이벤트는 독립적으로 주최되며 Processing Foundation과 관련이 없습니다. 이 이벤트에 관한 질문이나 우려 사항은 주최자에게 직접 문의하세요.",
         "activities_label": "활동",
         "report_issue": "이 페이지의 문제 신고",

--- a/pcd-website/src/i18n/locales/pt.json
+++ b/pcd-website/src/i18n/locales/pt.json
@@ -84,7 +84,7 @@
         "download_ics": "Baixar .ics",
         "read_more": "Ler mais…",
         "show_less": "Mostrar menos",
-        "disclaimer_with_org": "Este evento é organizado por {org} e não é afiliado à Processing Foundation. Para quaisquer dúvidas ou preocupações sobre este evento, entre em contato diretamente com os organizadores.",
+        "disclaimer_with_org": "Este evento é organizado por <em>{org}</em> e não é afiliado à Processing Foundation. Para quaisquer dúvidas ou preocupações sobre este evento, entre em contato diretamente com os organizadores.",
         "disclaimer_without_org": "Este evento é organizado de forma independente e não é afiliado à Processing Foundation. Para quaisquer dúvidas ou preocupações sobre este evento, entre em contato diretamente com os organizadores.",
         "activities_label": "Atividades",
         "report_issue": "Reportar um problema nesta página",

--- a/pcd-website/src/i18n/locales/zh-CN.json
+++ b/pcd-website/src/i18n/locales/zh-CN.json
@@ -84,7 +84,7 @@
         "download_ics": "下载 .ics",
         "read_more": "阅读更多…",
         "show_less": "收起",
-        "disclaimer_with_org": "本活动由 {org} 主办，与 Processing Foundation 无关。如对本活动有任何疑问，请直接联系主办方。",
+        "disclaimer_with_org": "本活动由 <em>{org}</em> 主办，与 Processing Foundation 无关。如对本活动有任何疑问，请直接联系主办方。",
         "disclaimer_without_org": "本活动为独立主办，与 Processing Foundation 无关。如对本活动有任何疑问，请直接联系主办方。",
         "activities_label": "活动类型",
         "report_issue": "举报此页面的问题",

--- a/pcd-website/src/i18n/locales/zh-TW.json
+++ b/pcd-website/src/i18n/locales/zh-TW.json
@@ -84,7 +84,7 @@
         "download_ics": "下載 .ics",
         "read_more": "閱讀更多…",
         "show_less": "收合",
-        "disclaimer_with_org": "本活動由 {org} 主辦，與 Processing Foundation 無關。如對本活動有任何疑問，請直接聯繫主辦單位。",
+        "disclaimer_with_org": "本活動由 <em>{org}</em> 主辦，與 Processing Foundation 無關。如對本活動有任何疑問，請直接聯繫主辦單位。",
         "disclaimer_without_org": "本活動為獨立主辦，與 Processing Foundation 無關。如對本活動有任何疑問，請直接聯繫主辦單位。",
         "activities_label": "活動類型",
         "report_issue": "回報此頁面的問題",

--- a/pcd-website/src/lib/nodes.ts
+++ b/pcd-website/src/lib/nodes.ts
@@ -38,8 +38,9 @@ export interface Node {
   details_html: string;
   details_text: string;
   event_activities: string[];
-  organizers: { name: string }[];
+  organizers: { name: string; name_html: string }[];
   organization_name?: string;
+  organization_name_html?: string;
   organization_url?: string;
   organization_type?: string;
   primary_contact: { name: string; email: string };
@@ -100,6 +101,16 @@ function markdownToHtml(markdown: string): string {
   return html.replace(/<a /g, '<a target="_blank" rel="noopener noreferrer" ');
 }
 
+// Render a short, single-line field (host or organization name) as inline
+// markdown. micromark wraps output in <p>…</p>; we strip that so the result
+// can sit inline. Same escaping/sanitization guarantees as markdownToHtml, and
+// these fields are PR-reviewed, so the output is safe to inject with v-html.
+function inlineMarkdownToHtml(text: string): string {
+  if (!text) return '';
+  const html = markdownToHtml(text).trim();
+  return html.replace(/^<p>/, '').replace(/<\/p>$/, '');
+}
+
 function markdownToText(markdown: string): string {
   return markdown
     .replace(/```[\s\S]*?```/g, '')
@@ -142,6 +153,7 @@ export async function loadNodes(): Promise<Node[]> {
     const event_end_date = normalizeOptionalText(input.event_end_date);
     const event_start_time = normalizeOptionalText(input.event_start_time);
     const event_end_time = normalizeOptionalText(input.event_end_time);
+    const organization_name = normalizeOptionalText(input.organization_name);
     const online_event = input.online_event ?? false;
     const location_tbd = !online_event && !address;
     const eventEntry = eventMap.get(input.id);
@@ -175,8 +187,14 @@ export async function loadNodes(): Promise<Node[]> {
       details_html,
       details_text,
       event_activities: input.event_activities,
-      organizers: input.organizers,
-      organization_name: normalizeOptionalText(input.organization_name),
+      organizers: input.organizers.map((o) => ({
+        name: o.name,
+        name_html: inlineMarkdownToHtml(o.name),
+      })),
+      organization_name,
+      organization_name_html: organization_name
+        ? inlineMarkdownToHtml(organization_name)
+        : undefined,
       organization_url: normalizeOptionalText(input.organization_url),
       organization_type: normalizeOptionalText(input.organization_type),
       primary_contact: input.primary_contact,


### PR DESCRIPTION
* Markdown support for HOST `name_html` and  BY `organization_name_html`.
* The event panel now renders these HTML-formatted names using `v-html` in relevant locations, including the hosts list and organization fields. 
* The panel's description clamp height is increased from 132px to 240px. Show more content before "read more"
* Button and link colors in the panel are updated for improved accessibility and visual clarity, especially for muted and hover states.
* The event disclaimer now wraps the organization name in `<em>` tags to make it italics.
* The venue icon now shows a pin also for "location TBD" instead of defaulting to the link icon.